### PR TITLE
Remove overriding constant warnings

### DIFF
--- a/lib/langchainrb_overrides/vectorsearch/pgvector.rb
+++ b/lib/langchainrb_overrides/vectorsearch/pgvector.rb
@@ -21,7 +21,7 @@ module Langchain::Vectorsearch
       "euclidean",
       "inner_product"
     ]
-    OPERATOR = "cosine"
+    DEFAULT_VECTOR_SEARCH_OPERATOR = "cosine"
 
     attr_reader :operator, :llm
     attr_accessor :model
@@ -36,7 +36,7 @@ module Langchain::Vectorsearch
       # These happen in the template files.
       # depends_on "neighbor"
 
-      @operator = DEFAULT
+      @operator = DEFAULT_VECTOR_SEARCH_OPERATOR
 
       super(llm: llm)
     end

--- a/lib/langchainrb_overrides/vectorsearch/pgvector.rb
+++ b/lib/langchainrb_overrides/vectorsearch/pgvector.rb
@@ -21,7 +21,7 @@ module Langchain::Vectorsearch
       "euclidean",
       "inner_product"
     ]
-    DEFAULT_OPERATOR = "cosine"
+    OPERATOR = "cosine"
 
     attr_reader :operator, :llm
     attr_accessor :model
@@ -36,7 +36,7 @@ module Langchain::Vectorsearch
       # These happen in the template files.
       # depends_on "neighbor"
 
-      @operator = DEFAULT_OPERATOR
+      @operator = DEFAULT
 
       super(llm: llm)
     end

--- a/lib/langchainrb_overrides/vectorsearch/pgvector.rb
+++ b/lib/langchainrb_overrides/vectorsearch/pgvector.rb
@@ -16,7 +16,7 @@ module Langchain::Vectorsearch
     #
 
     # The operators supported by the PostgreSQL vector search adapter
-    OPERATORS = [
+    VECTOR_SEARCH_OPERATORS = [
       "cosine",
       "euclidean",
       "inner_product"


### PR DESCRIPTION
This PR is meant to fix the warnings when using the langcahinrb_rails with PG Vector

```
/Users/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/langchainrb_rails-0.1.7/lib/langchainrb_overrides/vectorsearch/pgvector.rb:19: warning: already initialized constant Langchain::Vectorsearch::Pgvector::OPERATORS
web     | /Users/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/langchainrb-0.9.2/lib/langchain/vectorsearch/pgvector.rb:17: warning: previous definition of OPERATORS was here
web     | /Users/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/langchainrb_rails-0.1.7/lib/langchainrb_overrides/vectorsearch/pgvector.rb:24: warning: already initialized constant Langchain::Vectorsearch::Pgvector::DEFAULT_OPERATOR
web     | /Users/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/langchainrb-0.9.2/lib/langchain/vectorsearch/pgvector.rb:21: warning: previous definition of DEFAULT_OPERATOR was here
```
