### PR TITLE
Bump unicode gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
     to_bool (2.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode (0.4.4.4)
+    unicode (0.4.4.5)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)


### PR DESCRIPTION
This error should no longer be happening: https://github.com/patterns-ai-core/langchainrb?tab=readme-ov-file#problems in the new `unicode` version.